### PR TITLE
Archive all files on rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python download_and_zip.py
 
 4. **Output**:
    - The downloaded files will be saved in a `files` directory within your `Downloads` folder.
-   - The script will create a `files.zip` file containing all the downloaded files in your `Downloads` folder.
+   - The script will create a `files.zip` file containing **all files in the `files` directory**, so rerunning the script without new URLs still produces a complete archive.
 
 ## Customization
 

--- a/download_and_zip.py
+++ b/download_and_zip.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 # Placeholder for paths
-csv_file_path = 'path_to_your_csv_file.csv'  # Update with the actual CSV file path
+csv_file_path = os.environ.get('CSV_FILE_PATH', 'path_to_your_csv_file.csv')  # Update with the actual CSV file path or set CSV_FILE_PATH env var
 record_file_path = 'downloaded_urls.csv'  # Path to the CSV tracking downloaded URLs
 
 # Load the CSV file
@@ -66,10 +66,21 @@ if new_urls:
     else:
         new_urls_df.to_csv(record_file_path, index=False)
 
-# Create a zip file
+# Create a zip file containing all files in ``file_dir``
 zip_file_path = os.path.join(downloads_path, 'files.zip')
+
+# Collect all existing files in ``file_dir`` to ensure the archive always
+# contains every downloaded file even when the script is rerun without new
+# URLs.
+all_existing_files = [
+    os.path.join(file_dir, f) for f in os.listdir(file_dir) if os.path.isfile(os.path.join(file_dir, f))
+]
+
+# Merge newly downloaded file paths with the existing ones, avoiding duplicates
+all_files_to_zip = list(dict.fromkeys(all_existing_files + file_paths))
+
 with ZipFile(zip_file_path, 'w') as zipf:
-    for file_path in file_paths:
+    for file_path in all_files_to_zip:
         zipf.write(file_path, os.path.basename(file_path))
 
 print(f"Files have been downloaded and zipped into {zip_file_path}")


### PR DESCRIPTION
## Summary
- zip existing downloads along with new files
- clarify in README that rerunning still creates a full archive
- allow the CSV path to be set with `CSV_FILE_PATH`

## Testing
- `python -m py_compile download_and_zip.py`
- `CSV_FILE_PATH=urls.csv python download_and_zip.py` *(with sample URLs)*

------
https://chatgpt.com/codex/tasks/task_e_683ff8017c908327ac3a0443bc633ec1