### PR TITLE
Add helper utils and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ python download_and_zip.py
 
 - You can change the download folder and zip file location by modifying the `downloads_path` and `file_dir` variables.
 - The `record_file_path` keeps track of already downloaded URLs. You can change or reset this log if necessary.
+
+## Testing
+
+Run the automated tests with [pytest](https://docs.pytest.org/):
+
+```bash
+pytest
+```

--- a/download_and_zip.py
+++ b/download_and_zip.py
@@ -4,34 +4,14 @@ import requests
 from zipfile import ZipFile
 from pathlib import Path
 from urllib.parse import urlparse
+from helpers import ensure_scheme, append_to_log
 
 # Placeholder for paths
 csv_file_path = 'path_to_your_csv_file.csv'  # Update with the actual CSV file path
 record_file_path = 'downloaded_urls.csv'  # Path to the CSV tracking downloaded URLs
 
-# Load the CSV file
-df = pd.read_csv(csv_file_path)
-
-# Extract URLs from the 'poster URL' column
-urls = df['poster URL'].dropna().tolist()  # Ensure the CSV file has a column named 'poster URL'
-
-# Correct the URLs by adding the scheme if missing
-corrected_urls = ["https://" + url if not url.startswith("http") else url for url in urls]
-
-# Load the record of downloaded URLs
-if os.path.exists(record_file_path):
-    downloaded_df = pd.read_csv(record_file_path)
-    downloaded_urls = set(downloaded_df['url'])
-else:
-    downloaded_urls = set()
-
-# Directory to save downloaded files
-downloads_path = str(Path.home() / 'Downloads')
-file_dir = os.path.join(downloads_path, 'files')
-os.makedirs(file_dir, exist_ok=True)
-
-# Function to download a file
-def download_file(url, save_path):
+def download_file(url: str, save_path: str) -> bool:
+    """Download a single file."""
     try:
         response = requests.get(url)
         response.raise_for_status()
@@ -43,33 +23,56 @@ def download_file(url, save_path):
         print(f"Failed to download {url}: {e}")
         return False
 
-# Download all files, only if not already downloaded
-file_paths = []
-new_urls = []
-for i, url in enumerate(corrected_urls):
-    if url in downloaded_urls:
-        print(f"Already downloaded {url}")
-        continue
-    parsed_url_path = urlparse(url).path
-    file_extension = os.path.splitext(parsed_url_path)[1]
-    file_name = f"file_{i+1}{file_extension}"
-    local_file_path = os.path.join(file_dir, file_name)
-    if download_file(url, local_file_path):
-        file_paths.append(local_file_path)
-        new_urls.append(url)
 
-# Update the record of downloaded URLs
-if new_urls:
-    new_urls_df = pd.DataFrame(new_urls, columns=['url'])
+def main() -> None:
+    # Load the CSV file
+    df = pd.read_csv(csv_file_path)
+
+    # Extract URLs from the 'poster URL' column
+    urls = df['poster URL'].dropna().tolist()  # Ensure the CSV file has a column named 'poster URL'
+
+    # Correct the URLs by adding the scheme if missing
+    corrected_urls = [ensure_scheme(url) for url in urls]
+
+    # Load the record of downloaded URLs
     if os.path.exists(record_file_path):
-        new_urls_df.to_csv(record_file_path, mode='a', header=False, index=False)
+        downloaded_df = pd.read_csv(record_file_path)
+        downloaded_urls = set(downloaded_df['url'])
     else:
-        new_urls_df.to_csv(record_file_path, index=False)
+        downloaded_urls = set()
 
-# Create a zip file
-zip_file_path = os.path.join(downloads_path, 'files.zip')
-with ZipFile(zip_file_path, 'w') as zipf:
-    for file_path in file_paths:
-        zipf.write(file_path, os.path.basename(file_path))
+    # Directory to save downloaded files
+    downloads_path = str(Path.home() / 'Downloads')
+    file_dir = os.path.join(downloads_path, 'files')
+    os.makedirs(file_dir, exist_ok=True)
 
-print(f"Files have been downloaded and zipped into {zip_file_path}")
+    # Download all files, only if not already downloaded
+    file_paths = []
+    new_urls = []
+    for i, url in enumerate(corrected_urls):
+        if url in downloaded_urls:
+            print(f"Already downloaded {url}")
+            continue
+        parsed_url_path = urlparse(url).path
+        file_extension = os.path.splitext(parsed_url_path)[1]
+        file_name = f"file_{i+1}{file_extension}"
+        local_file_path = os.path.join(file_dir, file_name)
+        if download_file(url, local_file_path):
+            file_paths.append(local_file_path)
+            new_urls.append(url)
+
+    # Update the record of downloaded URLs
+    if new_urls:
+        append_to_log(record_file_path, new_urls)
+
+    # Create a zip file
+    zip_file_path = os.path.join(downloads_path, 'files.zip')
+    with ZipFile(zip_file_path, 'w') as zipf:
+        for file_path in file_paths:
+            zipf.write(file_path, os.path.basename(file_path))
+
+    print(f"Files have been downloaded and zipped into {zip_file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,25 @@
+import os
+import pandas as pd
+
+
+def ensure_scheme(url: str) -> str:
+    """Prepend https:// to the URL if no scheme is present."""
+    if url.startswith(('http://', 'https://')):
+        return url
+    return 'https://' + url
+
+
+def append_to_log(record_file_path: str, urls: list[str]) -> None:
+    """Append unique URLs to the CSV log file."""
+    existing_urls = set()
+    if os.path.exists(record_file_path):
+        existing_df = pd.read_csv(record_file_path)
+        if 'url' in existing_df.columns:
+            existing_urls = set(existing_df['url'])
+    unique_urls = [u for u in urls if u not in existing_urls]
+    if not unique_urls:
+        return
+    df = pd.DataFrame(unique_urls, columns=['url'])
+    mode = 'a' if os.path.exists(record_file_path) else 'w'
+    header = not os.path.exists(record_file_path)
+    df.to_csv(record_file_path, mode=mode, header=header, index=False)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from unittest.mock import patch
+from helpers import ensure_scheme, append_to_log
+
+
+def test_ensure_scheme_adds_https():
+    assert ensure_scheme('example.com/img.jpg') == 'https://example.com/img.jpg'
+    assert ensure_scheme('http://example.com') == 'http://example.com'
+    assert ensure_scheme('https://example.com') == 'https://example.com'
+
+
+def test_append_to_log_appends_unique_urls():
+    existing_df = pd.DataFrame(['http://old.com/img.jpg'], columns=['url'])
+    with patch('helpers.os.path.exists', return_value=True), \
+         patch('helpers.pd.read_csv', return_value=existing_df), \
+         patch('helpers.pd.DataFrame.to_csv', autospec=True) as mock_to_csv:
+        append_to_log('downloaded_urls.csv', ['http://old.com/img.jpg', 'http://new.com/img.jpg'])
+        mock_to_csv.assert_called_once()
+        written_df = mock_to_csv.call_args.args[0]
+        assert written_df['url'].tolist() == ['http://new.com/img.jpg']
+        assert mock_to_csv.call_args.args[1] == 'downloaded_urls.csv'
+        assert mock_to_csv.call_args.kwargs['mode'] == 'a'


### PR DESCRIPTION
## Summary
- add `helpers.py` with `ensure_scheme` and `append_to_log`
- refactor `download_and_zip.py` to use helpers and `main()` entry point
- create pytest unit tests for the helpers
- document test execution in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff81367c0832787878b8fd4eea47e