### PR TITLE
Add Flask web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,18 @@ Run the automated tests with [pytest](https://docs.pytest.org/):
 ```bash
 pytest
 ```
+
+## Web Interface
+
+You can also start a small web server to upload the CSV file and monitor
+download progress.
+
+```bash
+pip install flask
+python web_app.py
+```
+
+Navigate to `http://localhost:5000` in your browser, upload the CSV,
+and wait for the progress indicator to finish. When done, you can
+download the resulting zip file and preview thumbnails directly in the
+browser.

--- a/download_and_zip.py
+++ b/download_and_zip.py
@@ -1,17 +1,16 @@
-import pandas as pd
 import os
+import pandas as pd
 import requests
 from zipfile import ZipFile
 from pathlib import Path
 from urllib.parse import urlparse
+from typing import Iterable, Callable, List
+
 from helpers import ensure_scheme, append_to_log
 
-# Placeholder for paths
-csv_file_path = os.environ.get('CSV_FILE_PATH', 'path_to_your_csv_file.csv')  # Update with the actual CSV file path or set CSV_FILE_PATH env var
-record_file_path = 'downloaded_urls.csv'  # Path to the CSV tracking downloaded URLs
 
 def download_file(url: str, save_path: str) -> bool:
-    """Download a single file."""
+    """Download a single file and save it locally."""
     try:
         response = requests.get(url)
         response.raise_for_status()
@@ -24,72 +23,67 @@ def download_file(url: str, save_path: str) -> bool:
         return False
 
 
-def main() -> None:
-    # Load the CSV file
-    df = pd.read_csv(csv_file_path)
-
-    # Extract URLs from the 'poster URL' column
-    urls = df['poster URL'].dropna().tolist()  # Ensure the CSV file has a column named 'poster URL'
-
-    # Correct the URLs by adding the scheme if missing
-    corrected_urls = [ensure_scheme(url) for url in urls]
-
-    # Load the record of downloaded URLs
+def download_files(
+    urls: Iterable[str],
+    download_dir: str,
+    record_file_path: str,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> List[str]:
+    """Download multiple files and update the record file."""
     if os.path.exists(record_file_path):
         downloaded_df = pd.read_csv(record_file_path)
         downloaded_urls = set(downloaded_df['url'])
     else:
         downloaded_urls = set()
 
-    # Directory to save downloaded files
-    downloads_path = str(Path.home() / 'Downloads')
-    file_dir = os.path.join(downloads_path, 'files')
-    os.makedirs(file_dir, exist_ok=True)
+    os.makedirs(download_dir, exist_ok=True)
+    file_paths: List[str] = []
+    new_urls: List[str] = []
+    total = len(list(urls)) if not isinstance(urls, list) else len(urls)
 
-    # Download all files, only if not already downloaded
-    file_paths = []
-    new_urls = []
-    for i, url in enumerate(corrected_urls):
+    for index, url in enumerate(urls, start=1):
         if url in downloaded_urls:
             print(f"Already downloaded {url}")
+            if progress_callback:
+                progress_callback(index, total)
             continue
         parsed_url_path = urlparse(url).path
-        file_extension = os.path.splitext(parsed_url_path)[1]
-        file_name = f"file_{i+1}{file_extension}"
-        local_file_path = os.path.join(file_dir, file_name)
-        if download_file(url, local_file_path):
-            file_paths.append(local_file_path)
+        extension = os.path.splitext(parsed_url_path)[1] or '.jpg'
+        file_name = f"file_{index}{extension}"
+        local_file = os.path.join(download_dir, file_name)
+        if download_file(url, local_file):
+            file_paths.append(local_file)
             new_urls.append(url)
+        if progress_callback:
+            progress_callback(index, total)
 
-    # Update the record of downloaded URLs
     if new_urls:
         append_to_log(record_file_path, new_urls)
 
-    # Create a zip file
-    zip_file_path = os.path.join(downloads_path, 'files.zip')
+    return file_paths
+
+
+def create_zip(file_paths: Iterable[str], zip_file_path: str) -> None:
+    """Create a zip archive containing all provided file paths."""
     with ZipFile(zip_file_path, 'w') as zipf:
         for file_path in file_paths:
-            zipf.write(file_path, os.path.basename(file_path))
+            if os.path.isfile(file_path):
+                zipf.write(file_path, os.path.basename(file_path))
 
+
+def main() -> None:
+    csv_file_path = os.environ.get('CSV_FILE_PATH', 'path_to_your_csv_file.csv')
+    record_file_path = 'downloaded_urls.csv'
+    downloads_path = str(Path.home() / 'Downloads')
+    file_dir = os.path.join(downloads_path, 'files')
+    zip_file_path = os.path.join(downloads_path, 'files.zip')
+
+    df = pd.read_csv(csv_file_path)
+    urls = [ensure_scheme(u) for u in df['poster URL'].dropna().tolist()]
+
+    file_paths = download_files(urls, file_dir, record_file_path)
+    create_zip(file_paths, zip_file_path)
     print(f"Files have been downloaded and zipped into {zip_file_path}")
-
-# Create a zip file of all files in the download directory
-
-# Collect all existing files in ``file_dir`` to ensure the archive always
-# contains every downloaded file even when the script is rerun without new
-# URLs.
-all_existing_files = [
-    os.path.join(file_dir, f) for f in os.listdir(file_dir) if os.path.isfile(os.path.join(file_dir, f))
-]
-
-# Merge newly downloaded file paths with the existing ones, avoiding duplicates
-all_files_to_zip = list(dict.fromkeys(all_existing_files + file_paths))
-
-with ZipFile(zip_file_path, 'w') as zipf:
-    for file_name in os.listdir(file_dir):
-        file_path = os.path.join(file_dir, file_name)
-        if os.path.isfile(file_path):
-            zipf.write(file_path, file_name)
 
 
 if __name__ == "__main__":

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,112 @@
+import os
+import threading
+from pathlib import Path
+from flask import (
+    Flask,
+    request,
+    redirect,
+    url_for,
+    jsonify,
+    send_file,
+    send_from_directory,
+    Response,
+)
+import pandas as pd
+from download_and_zip import download_files, create_zip
+from helpers import ensure_scheme
+
+app = Flask(__name__)
+
+progress = {
+    "total": 0,
+    "completed": 0,
+    "done": False,
+    "zip_path": "",
+}
+
+def download_worker(urls):
+    downloads_path = str(Path.home() / 'Downloads')
+    file_dir = os.path.join(downloads_path, 'files')
+    zip_file = os.path.join(downloads_path, 'files.zip')
+
+    def update_progress(current, total):
+        progress["total"] = total
+        progress["completed"] = current
+
+    file_paths = download_files(urls, file_dir, 'downloaded_urls.csv', update_progress)
+    create_zip(file_paths, zip_file)
+    progress["done"] = True
+    progress["zip_path"] = zip_file
+
+@app.route('/', methods=['GET'])
+def index():
+    return Response(
+        """
+        <html>
+        <body>
+            <h1>Bulk Image Downloader</h1>
+            <form action="/upload" method="post" enctype="multipart/form-data">
+                <input type="file" name="file" accept=".csv" required>
+                <input type="submit" value="Upload">
+            </form>
+            <div id="status"></div>
+            <script>
+            async function poll(){
+                const res = await fetch('/progress');
+                const data = await res.json();
+                if(data.total){
+                    document.getElementById('status').innerText = `Downloaded ${data.completed} of ${data.total}`;
+                }
+                if(data.done){
+                    document.getElementById('status').innerHTML += '<br><a href="/download">Download Zip</a><br><a href="/thumbnails">View Thumbnails</a>';
+                    clearInterval(interval);
+                }
+            }
+            const interval = setInterval(poll, 2000);
+            </script>
+        </body>
+        </html>
+        """,
+        mimetype='text/html'
+    )
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file:
+        return redirect(url_for('index'))
+    df = pd.read_csv(file)
+    urls = [ensure_scheme(u) for u in df['poster URL'].dropna().tolist()]
+    progress.update({"total": len(urls), "completed": 0, "done": False, "zip_path": ""})
+    thread = threading.Thread(target=download_worker, args=(urls,))
+    thread.start()
+    return redirect(url_for('index'))
+
+@app.route('/progress')
+def get_progress():
+    return jsonify(progress)
+
+@app.route('/download')
+def download_zip():
+    if progress.get("zip_path") and os.path.exists(progress["zip_path"]):
+        return send_file(progress["zip_path"], as_attachment=True)
+    return "No file", 404
+
+@app.route('/thumbnails')
+def thumbnails():
+    downloads_path = str(Path.home() / 'Downloads' / 'files')
+    if not os.path.isdir(downloads_path):
+        return "No images", 404
+    items = os.listdir(downloads_path)
+    images = ''.join(f'<img src="/files/{f}" height="100">' for f in items)
+    html = f"<html><body>{images}</body></html>"
+    return Response(html, mimetype='text/html')
+
+@app.route('/files/<path:filename>')
+def serve_file(filename: str):
+    downloads_path = str(Path.home() / 'Downloads' / 'files')
+    return send_from_directory(downloads_path, filename)
+
+if __name__ == '__main__':
+    app.run(debug=True)
+


### PR DESCRIPTION
## Summary
- refactor `download_and_zip` to provide reusable functions
- add `web_app.py` to upload a CSV via Flask and track download progress
- document the new web interface in README

## Testing
- `pip install pandas requests flask -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d6df4e3883278fcd41d4e2358386